### PR TITLE
Refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Perhaps the easiest way to demonstrate the terminology, is to simply use the ter
 
 `track_progress` reports the progress of processing an **iterable** (or **stream**) of **records**.
 
-Progress **conditions** are **met** which **trigger** the **creation** of **reports**. By default a **report** causes a message to be printed to `stdout`.
+Progress **conditions** are **met** which **trigger** the **creation** of **reports**. By default, a **report** causes a message to be printed to `stdout`.
 
 
 #### Coding Style

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,26 @@ Simple cases can also be done using a lambda:
     Got one!
     Got one!
 
+Report values available
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The following values are available in every report for use in the ``format_callback``:
+
+.. table::
+   :widths: auto
+
+   ============================== =================== =======================================================================================================================================
+   Value                          Type                Meaning
+   ============================== =================== =======================================================================================================================================
+   ``{records_seen}``             int                 The number of records processed so far.
+   ``{total}``                    Optional[int]       The total of records in the iterable, if known. Else ``None``
+   ``{percent_complete}``         Optional[float]     The percentage of records processed so far. ``None`` if ``{total}`` is ``None`` or ``records_seen`` = 0
+   ``{time_taken}``               timedelta           The amount of time that processing has taken thus far.
+   ``{estimated_time_remaining}`` Optional[timedelta] The estimated amount of time needed in order to process the rest of the records (simple linear estimate). ``None`` if total is ``None``
+   ``{items_per_second}``         Optional[float]     The number of records processed so far / the number of seconds elapsed. ``None`` if no time have elapsed.
+   ``{idle_time}``                timedelta           The amount of idle time between the previous record's processing and this record's arrival.
+   ============================== =================== =======================================================================================================================================
+
 Customizing the print behaviour
 -------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ By changing the parameters passed to ``track_progress``, you can customize how f
         every_n_records: Optional[int] = None, # Reports every n records
         every_n_seconds: Optional[float] = None, # Reports every n seconds
         every_n_seconds_idle: Optional[float] = None, # Report every n seconds, but only if there hasn’t been any progress. Useful for infinite streams
-        ignore_first_iteration: bool = True, # Don’t report on the first iteration
-        last_iteration: bool = False # Report after the last iteration
+        report_first_record: bool = False, # Report after the first record
+        report_last_record: bool = False # Report after the last record
         ) -> None
 
 Examples

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ By changing the parameters passed to ``track_progress``, you can customize how f
         iterable: Iterable[T], # The iterable to iterate over
         total: Optional[int] = None, # Override for the total message count, defaults to len(iterable)
         callback: Callable[[str], Any] = print, # A function (f(str) -> None) that gets called each time a condition matches
-        format_callback: Callable[..., str] = default_format_callback, # A function (f(str) -> str) that formats the progress values into a string.
+        format_callback: Callable[[Dict[str, Any], Set[str]], str] = default_format_callback, # A function (f(str) -> str) that formats the progress values into a string.
         every_n_percent: Optional[float] = None, # Reports after every n percent
         every_n_records: Optional[int] = None, # Reports every n records
         every_n_seconds: Optional[float] = None, # Reports every n seconds
@@ -169,14 +169,14 @@ This can be used to perform advanced formatting, or to add internationalization/
 
 .. code:: python
 
-    def format_en_francais(**kwargs):
-        i = kwargs["i"]
-        total = kwargs["total"]
+    def format_en_francais(report: Dict[str, Any], reasons: Set[str]):
+        i = report["i"]
+        total = report["total"]
         if total is None or i == total:
             format_string = "{i} messages traités en {time_taken}"
         else:
             format_string = "{i}/{total} messages traités en {time_taken} (temps restant: {estimated_time_remaining})"
-        return format_string.format(**kwargs)
+        return format_string.format(**report)
 
     for poste in track_progress(postes, every_n_records=100, format_callback=format_en_francais):
         traité(poste)

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ By changing the parameters passed to ``track_progress``, you can customize how f
         total: Optional[int] = None, # Override for the total message count, defaults to len(iterable)
         callback: Callable[[str], Any] = print, # A function (f(str) -> None) that gets called each time a condition matches
         format_callback: Callable[..., str] = default_format_callback, # A function (f(str) -> str) that formats the progress values into a string.
-        format_string: Optional[str] = None, # An override for the default format strings.
         every_n_percent: Optional[float] = None, # Reports after every n percent
         every_n_records: Optional[int] = None, # Reports every n records
         every_n_seconds: Optional[float] = None, # Reports every n seconds
@@ -173,17 +172,31 @@ This can be used to perform advanced formatting, or to add internationalization/
     def format_en_francais(**kwargs):
         i = kwargs["i"]
         total = kwargs["total"]
-        if format_string is None:
-            if total is None or i == total:
-                format_string = "{i} messages traités en {time_taken}"
-            else:
-                format_string = "{i}/{total} messages traités en {time_taken} (temps restant: {estimated_time_remaining})"
+        if total is None or i == total:
+            format_string = "{i} messages traités en {time_taken}"
+        else:
+            format_string = "{i}/{total} messages traités en {time_taken} (temps restant: {estimated_time_remaining})"
         return format_string.format(**kwargs)
 
     for poste in track_progress(postes, every_n_records=100, format_callback=format_en_francais):
         traité(poste)
 
 (Veuillez excuser toute erreur en français. C'est le résultat de Google Translate.)
+
+Simple cases can also be done using a lambda:
+
+.. code:: python
+
+    >>> from progress_tracker import track_progress
+    >>>
+    >>> for _ in track_progress(list(range(5)), every_n_records=1, format_callback=lambda **kwargs: "Got one!"):
+    ...     continue
+    ...
+    Got one!
+    Got one!
+    Got one!
+    Got one!
+    Got one!
 
 Customizing the print behaviour
 -------------------------------

--- a/README.rst
+++ b/README.rst
@@ -156,8 +156,15 @@ As seen in the previous example, you can combine multiple conditions together to
 
 Each of the conditions are combined using an OR operator, meaning that if any condition is met, a report is created.
 
-At most a single report is created per processed record.
 Even if multiple conditions are met simultaneously, only a single report will be created.
+
+Report Creation Invariants
+--------------------------
+
+Report creation observes two invariants:
+
+1. At most a single report is created per processed record.
+2. Reports are only created in response to a record being processed.
 
 Customizing the report formatting / Internationalization
 --------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ By changing the parameters passed to ``track_progress``, you can customize how f
         callback: Callable[[str], Any] = print, # A function (f(str) -> None) that gets called each time a condition matches
         format_callback: Callable[..., str] = default_format_callback, # A function (f(str) -> str) that formats the progress values into a string.
         format_string: Optional[str] = None, # An override for the default format strings.
-        every_x_percent: Optional[float] = None, # Reports after every x percent
+        every_n_percent: Optional[float] = None, # Reports after every n percent
         every_n_records: Optional[int] = None, # Reports every n records
         every_n_seconds: Optional[float] = None, # Reports every n seconds
         every_n_seconds_idle: Optional[float] = None, # Report every n seconds, but only if there hasn’t been any progress. Useful for infinite streams
@@ -89,12 +89,12 @@ The ``every_n_records`` parameter will trigger a report after every nth record i
 Print after every x percent of records are processed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``every_x_percent`` parameter will trigger a report after every xth percent of records are processed. 
+The ``every_n_percent`` parameter will trigger a report after every nth percent of records are processed. 
 
 .. code:: python
 
     >>> from progress_tracker import track_progress
-    >>> for _ in track_progress(list(range(1000)), every_x_percent=10):
+    >>> for _ in track_progress(list(range(1000)), every_n_percent=10):
     ...     continue
     ...
     100/1000 (10.0%) in 0:00:00.000114 (Time left: 0:00:00.001026)
@@ -108,10 +108,10 @@ The ``every_x_percent`` parameter will trigger a report after every xth percent 
     900/1000 (90.0%) in 0:00:00.000979 (Time left: 0:00:00.000109)
     1000 in 0:00:00.001086
 
-``every_x_percent`` only works for bounded iterables. For unbounded iterables (ex. streams), ``every_x_percent`` cannot be used and will raise an ``Exception``.
+``every_n_percent`` only works for bounded iterables. For unbounded iterables (ex. streams), ``every_n_percent`` cannot be used and will raise an ``Exception``.
 
 At most a single report is generated per processed record. Even if processing of a single record would meet the conditions multiple times 
-(ex. if ``every_x_percent=10``, but there are only 2 records, then processing each record causes 50%, or 5 * 10%, progress), only a single report is created (containing the latest values).
+(ex. if ``every_n_percent=10``, but there are only 2 records, then processing each record causes 50%, or 5 * 10%, progress), only a single report is created (containing the latest values).
 
 Print every n records OR every n seconds during processing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/progress_tracker/progress_tracker.py
+++ b/progress_tracker/progress_tracker.py
@@ -1,21 +1,23 @@
 from datetime import datetime, timedelta
 
 from progress_tracker.timeout import Timeout
-from typing import Any, Callable, Dict, Generic, Iterable, Optional, Sized, Type, TypeVar, cast
+from typing import Any, Callable, Dict, Generic, Iterable, Optional, Set, Sized, Type, TypeVar, cast
 from types import TracebackType
 
 T = TypeVar("T")
 
 
-def default_format_callback(**kwargs: Optional[str]) -> str:
-    i = kwargs["i"]
-    total = kwargs["total"]
-    if total is None or i == total:
-        format_string = "{i} in {time_taken}"
+def default_format_callback(report: Dict[str, Any], reasons: Set[str]) -> str:
+    records_seen = report["records_seen"]
+    total = report["total"]
+    if "every_n_seconds_idle" in reasons:
+        format_string = "Was idle for {idle_time}"
+    elif total is None or records_seen == total:
+        format_string = "{records_seen} in {time_taken}"
     else:
-        format_string = "{i}/{total} ({percent_complete}%) in {time_taken} (Time left: {estimated_time_remaining})"
+        format_string = "{records_seen}/{total} ({percent_complete}%) in {time_taken} (Time left: {estimated_time_remaining})"
 
-    return format_string.format(**kwargs)
+    return format_string.format(**report)
 
 
 class ProgressTracker(Generic[T]):
@@ -28,7 +30,7 @@ class ProgressTracker(Generic[T]):
     def __init__(self, iterable: Iterable[T],
                  total: Optional[int] = None,
                  callback: Callable[[str], Any] = print,
-                 format_callback: Callable[..., str] = default_format_callback,
+                 format_callback: Callable[[Dict[str, Any], Set[str]], str] = default_format_callback,
                  every_n_percent: Optional[float] = None,
                  every_n_records: Optional[int] = None,
                  every_n_seconds: Optional[float] = None,
@@ -69,18 +71,30 @@ class ProgressTracker(Generic[T]):
         self.end_time: Optional[datetime] = None
         self.total_time: Optional[timedelta] = None
 
-        self.items_seen = 0
-        self.times_callback_called = 0
+        self.records_seen = 0
+        self.reports_raised = 0
 
     def __iter__(self) -> Iterable[T]:
         with self:
-            for index, item in enumerate(self.iterable):
-                self.items_seen += 1
-                yield item
-                check = self.check(index + 1)
-                if check is not None:
-                    self.callback(self.format_callback(**check))
-                    self.times_callback_called += 1
+            if self.timeout is not None:
+                self.timeout.reset()
+            if self.idle_timeout is not None:
+                self.idle_timeout.reset()
+
+            for item in self.iterable:
+                # Has it been a while since we last saw a record?
+                if self.idle_timeout is not None and self.idle_timeout.is_overdue():
+                    self.raise_report(set(["every_n_seconds_idle"]))
+
+                self.records_seen += 1
+                yield item  # Process record
+
+                if self.idle_timeout is not None:
+                    self.idle_timeout.reset()
+
+                reasons_to_report = self.should_report()
+                if reasons_to_report:
+                    self.raise_report(reasons_to_report)
 
     def __enter__(self) -> None:
         self.start_time = datetime.utcnow()
@@ -88,58 +102,54 @@ class ProgressTracker(Generic[T]):
     def __exit__(self, exc_type: Optional[Type[Exception]], value: Optional[Exception], traceback: Optional[TracebackType]) -> None:
         self.complete()
 
-    def should_report(self, i: int) -> bool:
-        should_report = False
+    def raise_report(self, reasons_to_report: Set[str]) -> None:
+        self.callback(self.format_callback(self.create_report(), reasons_to_report))
+        self.reports_raised += 1
+
+    def should_report(self) -> Set[str]:
+        reasons_to_report: Set[str] = set()
         if self.timeout is not None and self.timeout.is_overdue():
-            should_report = True
+            reasons_to_report.add("every_n_seconds")
             self.timeout.reset()
-        if self.idle_timeout is not None and self.idle_timeout.is_overdue():
-            should_report = True
+
         if self.total is not None and self.every_n_percent is not None and self.next_percent is not None:
-            percent_complete = (i / self.total) * 100
+            percent_complete: float = (self.records_seen / self.total) * 100
             if percent_complete >= self.next_percent:
-                should_report = True
+                reasons_to_report.add("every_n_percent")
                 self.next_percent = ((int(percent_complete) // self.every_n_percent) + 1) * self.every_n_percent
-        if self.every_n_records is not None and self.next_record_count is not None and i >= self.next_record_count:
-            should_report = True
-            self.next_record_count = ((i // self.every_n_records) + 1) * self.every_n_records
-        if self.total is not None and self.report_last_record and i == self.total:
-            should_report = True
 
-        return should_report
+        if self.every_n_records is not None and self.next_record_count is not None and self.records_seen >= self.next_record_count:
+            reasons_to_report.add("every_n_records")
+            self.next_record_count = ((self.records_seen // self.every_n_records) + 1) * self.every_n_records
 
-    # Returns a tuple that contains all of the usual values that you want to print out.
-    def check(self, i: int) -> Optional[Dict[str, Any]]:
+        if self.total is not None and self.report_last_record and self.records_seen == self.total:
+            reasons_to_report.add("report_last_record")
+
+        return reasons_to_report
+
+    def create_report(self) -> Dict[str, Any]:
         assert self.start_time is not None
-        result: Optional[Dict[str, Any]]
-        if self.should_report(i):
-            time_taken = datetime.utcnow() - self.start_time
-            percent_complete: Optional[float]
-            estimated_time_remaining: Optional[timedelta]
-            if self.total is not None:
-                percent_complete = (i / self.total) * 100
-                estimated_time_remaining = timedelta(seconds=((100 - percent_complete) / percent_complete) * time_taken.total_seconds()) if percent_complete != 0 else None
-            else:
-                percent_complete = None
-                estimated_time_remaining = None
-
-            items_per_second = i / time_taken.total_seconds() if time_taken.total_seconds() != 0 else None
-
-            result = {
-                'i': i,
-                'total': self.total,
-                'percent_complete': percent_complete,
-                'time_taken': time_taken,
-                'estimated_time_remaining': estimated_time_remaining,
-                'items_per_second': items_per_second
-            }
+        time_taken = datetime.utcnow() - self.start_time
+        percent_complete: Optional[float]
+        estimated_time_remaining: Optional[timedelta]
+        if self.total is not None:
+            percent_complete = (self.records_seen / self.total) * 100
+            estimated_time_remaining = timedelta(seconds=((100 - percent_complete) / percent_complete) * time_taken.total_seconds()) if percent_complete != 0 else None
         else:
-            result = None
+            percent_complete = None
+            estimated_time_remaining = None
 
-        if self.idle_timeout is not None:
-            self.idle_timeout.reset()
+        items_per_second = self.records_seen / time_taken.total_seconds() if time_taken.total_seconds() != 0 else None
 
-        return result
+        return {
+            'records_seen': self.records_seen,
+            'total': self.total,
+            'percent_complete': percent_complete,
+            'time_taken': time_taken,
+            'estimated_time_remaining': estimated_time_remaining,
+            'items_per_second': items_per_second,
+            'idle_time': self.idle_timeout.time_elapsed() if self.idle_timeout is not None else None
+        }
 
     def complete(self) -> None:
         assert self.start_time is not None

--- a/progress_tracker/progress_tracker.py
+++ b/progress_tracker/progress_tracker.py
@@ -31,7 +31,7 @@ class ProgressTracker(Generic[T]):
                  callback: Callable[[str], Any] = print,
                  format_callback: Callable[..., str] = default_format_callback,
                  format_string: Optional[str] = None,
-                 every_x_percent: Optional[float] = None,
+                 every_n_percent: Optional[float] = None,
                  every_n_records: Optional[int] = None,
                  every_n_seconds: Optional[float] = None,
                  every_n_seconds_idle: Optional[float] = None,
@@ -59,14 +59,14 @@ class ProgressTracker(Generic[T]):
                     proper_grammar = ", ".join(invalid_arg_strings[:-1]) + ', nor {0}'.format(invalid_arg_strings[-1]) if len(invalid_arg_strings) > 1 else invalid_arg_strings[0]
                     raise Exception("Format string cannot include {0} if total length is not available.".format(proper_grammar))
 
-            if every_x_percent is not None:
-                raise Exception("Cannot ask to report 'every_x_percent' if total length is not available")
+            if every_n_percent is not None:
+                raise Exception("Cannot ask to report 'every_n_percent' if total length is not available")
 
         self.callback = callback
         self.format_callback = format_callback
 
-        self.every_x_percent = every_x_percent
-        self.next_percent = every_x_percent if ignore_first_iteration else 0
+        self.every_n_percent = every_n_percent
+        self.next_percent = every_n_percent if ignore_first_iteration else 0
 
         self.every_n_records = every_n_records
         self.next_record_count = every_n_records if ignore_first_iteration else 0
@@ -106,11 +106,11 @@ class ProgressTracker(Generic[T]):
             self.timeout.reset()
         if self.idle_timeout is not None and self.idle_timeout.is_overdue():
             should_report = True
-        if self.total is not None and self.every_x_percent is not None and self.next_percent is not None:
+        if self.total is not None and self.every_n_percent is not None and self.next_percent is not None:
             percent_complete = (i / self.total) * 100
             if percent_complete >= self.next_percent:
                 should_report = True
-                self.next_percent = ((int(percent_complete) // self.every_x_percent) + 1) * self.every_x_percent
+                self.next_percent = ((int(percent_complete) // self.every_n_percent) + 1) * self.every_n_percent
         if self.every_n_records is not None and self.next_record_count is not None and i >= self.next_record_count:
             should_report = True
             self.next_record_count = ((i // self.every_n_records) + 1) * self.every_n_records

--- a/progress_tracker/progress_tracker.py
+++ b/progress_tracker/progress_tracker.py
@@ -35,8 +35,8 @@ class ProgressTracker(Generic[T]):
                  every_n_records: Optional[int] = None,
                  every_n_seconds: Optional[float] = None,
                  every_n_seconds_idle: Optional[float] = None,
-                 ignore_first_iteration: bool = True,
-                 last_iteration: bool = False) -> None:
+                 report_first_record: bool = False,
+                 report_last_record: bool = False) -> None:
 
         self.iterable = iterable
 
@@ -66,15 +66,15 @@ class ProgressTracker(Generic[T]):
         self.format_callback = format_callback
 
         self.every_n_percent = every_n_percent
-        self.next_percent = every_n_percent if ignore_first_iteration else 0
+        self.next_percent = 0 if report_first_record else every_n_percent
 
         self.every_n_records = every_n_records
-        self.next_record_count = every_n_records if ignore_first_iteration else 0
+        self.next_record_count = 0 if report_first_record else every_n_records
 
         self.timeout = Timeout(timedelta(seconds=every_n_seconds)) if every_n_seconds is not None else None
         self.idle_timeout = Timeout(timedelta(seconds=every_n_seconds_idle)) if every_n_seconds_idle is not None else None
 
-        self.last_iteration = last_iteration
+        self.report_last_record = report_last_record
 
         self.start_time: Optional[datetime] = None
         self.end_time: Optional[datetime] = None
@@ -114,7 +114,7 @@ class ProgressTracker(Generic[T]):
         if self.every_n_records is not None and self.next_record_count is not None and i >= self.next_record_count:
             should_report = True
             self.next_record_count = ((i // self.every_n_records) + 1) * self.every_n_records
-        if self.total is not None and self.last_iteration and i == self.total:
+        if self.total is not None and self.report_last_record and i == self.total:
             should_report = True
 
         return should_report

--- a/progress_tracker/timeout.py
+++ b/progress_tracker/timeout.py
@@ -6,7 +6,7 @@ class Timeout(object):
     def __init__(self, delta: timedelta, start_time: Optional[datetime] = None) -> None:
         self.delta = delta
         self.start_time = start_time if start_time else datetime.utcnow()
-        self.stop_time = None
+        self.stop_time: Optional[datetime] = None
         self.deadline = self.start_time + self.delta
 
     def reset(self) -> None:

--- a/progress_tracker/timeout.py
+++ b/progress_tracker/timeout.py
@@ -6,10 +6,12 @@ class Timeout(object):
     def __init__(self, delta: timedelta, start_time: Optional[datetime] = None) -> None:
         self.delta = delta
         self.start_time = start_time if start_time else datetime.utcnow()
+        self.stop_time = None
         self.deadline = self.start_time + self.delta
 
     def reset(self) -> None:
         self.start_time = datetime.utcnow()
+        self.stop_time = None
         self.deadline = self.start_time + self.delta
 
     def is_overdue(self) -> bool:
@@ -19,4 +21,7 @@ class Timeout(object):
         return self.deadline - datetime.utcnow()
 
     def time_elapsed(self) -> timedelta:
-        return datetime.utcnow() - self.start_time
+        return datetime.utcnow() - self.start_time if self.stop_time is None else (self.stop_time - self.start_time)
+
+    def stop(self) -> None:
+        self.stop_time = datetime.utcnow()

--- a/progress_tracker/timeout.py
+++ b/progress_tracker/timeout.py
@@ -5,13 +5,18 @@ from typing import Optional
 class Timeout(object):
     def __init__(self, delta: timedelta, start_time: Optional[datetime] = None) -> None:
         self.delta = delta
-        self.deadline = start_time + self.delta if start_time else datetime.utcnow() + self.delta
+        self.start_time = start_time if start_time else datetime.utcnow()
+        self.deadline = self.start_time + self.delta
 
     def reset(self) -> None:
-        self.deadline = datetime.utcnow() + self.delta
+        self.start_time = datetime.utcnow()
+        self.deadline = self.start_time + self.delta
 
     def is_overdue(self) -> bool:
         return self.deadline < datetime.utcnow()
 
     def time_remaining(self) -> timedelta:
         return self.deadline - datetime.utcnow()
+
+    def time_elapsed(self) -> timedelta:
+        return datetime.utcnow() - self.start_time

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ ignore = E501
 [flake8]
 ignore = E501
 exclude=__init__.py
+
+[mypy]
+strict_optional = False

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -63,7 +63,7 @@ class BoundedTests(unittest.TestCase):
         # [0,5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, ignore_first_iteration=False, callback=lambda _: self.increment()))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, report_first_record=True, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 21)
 
@@ -79,7 +79,7 @@ class BoundedTests(unittest.TestCase):
         # [0,5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_records=5, ignore_first_iteration=False, callback=lambda _: self.increment()))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_records=5, report_first_record=True, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 21)
 

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -79,6 +79,13 @@ class BoundedTests(unittest.TestCase):
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 20)
 
+    def test_first_and_last_records(self):
+        NUMBER_OF_ITERATIONS = 101
+
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), report_first_record=True, report_last_record=True, callback=lambda _: self.increment()))
+        self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
+        self.assertEqual(self.callback_count, 2)
+
     def test_every_n_percent_while_including_first(self):
         # [0,5,10...100]
         NUMBER_OF_ITERATIONS = 101
@@ -161,6 +168,13 @@ class UnboundedTests(unittest.TestCase):
         results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), total=NUMBER_OF_ITERATIONS, every_n_percent=5, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 20)
+
+    def test_first_and_last_records(self):
+        NUMBER_OF_ITERATIONS = 101
+
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), report_first_record=True, report_last_record=True, callback=lambda _: self.increment()))
+        self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
+        self.assertEqual(self.callback_count, 2)
 
     def test_every_n_records(self):
         # [5,10...100]

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -71,6 +71,21 @@ class BoundedTests(unittest.TestCase):
     def increment(self):
         self.callback_count += 1
 
+    def test_empty_iterable(self):
+        # []
+        NUMBER_OF_ITERATIONS = 0
+
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS),
+                                      every_n_percent=0,
+                                      every_n_records=0,
+                                      every_n_seconds=0,
+                                      every_n_seconds_idle=0,
+                                      report_first_record=True,
+                                      report_last_record=True,
+                                      callback=lambda _: self.increment()))
+        self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
+        self.assertEqual(self.callback_count, 0)
+
     def test_every_n_percent(self):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
@@ -155,6 +170,21 @@ class UnboundedTests(unittest.TestCase):
 
     def increment(self):
         self.callback_count += 1
+
+    def test_empty_iterable(self):
+        # []
+        NUMBER_OF_ITERATIONS = 0
+
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)),
+                                      #   every_n_percent=0,
+                                      every_n_records=0,
+                                      every_n_seconds=0,
+                                      every_n_seconds_idle=0,
+                                      report_first_record=True,
+                                      report_last_record=True,
+                                      callback=lambda _: self.increment()))
+        self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
+        self.assertEqual(self.callback_count, 0)
 
     def test_every_n_percent(self):
         # [5,10...100]

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -13,14 +13,14 @@ class CustomFormatStrings(unittest.TestCase):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_callback, format_string="{i}"))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_callback, format_callback=lambda **kwargs: "{i}".format(**kwargs)))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
 
     def test_custom_unbounded(self):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_n_records=5, callback=self.custom_callback, format_string="{i}"))
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_n_records=5, callback=self.custom_callback, format_callback=lambda **kwargs: "{i}".format(**kwargs)))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
 
 
@@ -31,7 +31,7 @@ class CustomFormatFunctions(unittest.TestCase):
     def custom_print_callback(self, message):
         self.callback_results[message] += 1
 
-    def custom_format_callback(self, format_string, **kwargs):
+    def custom_format_callback(self, **kwargs):
         return "Odd" if kwargs['i'] % 2 == 1 else "Even"
 
     def test_custom_bounded(self):
@@ -182,10 +182,7 @@ class UnboundedTests(unittest.TestCase):
         self.assertEqual(self.callback_count, 19)
 
     def test_format_strings(self):
-        with self.assertRaises(Exception):
-            track_progress((i for i in range(0, 100)), format_string="{percent_complete}", every_n_records=11, callback=lambda _: self.increment())
-
-        track_progress((i for i in range(0, 100)), total=100, format_string="{percent_complete}", every_n_records=11, callback=lambda _: self.increment())
+        track_progress((i for i in range(0, 100)), total=100, format_callback=lambda **kwargs: "{percent_complete}".format(**kwargs), every_n_records=11, callback=lambda _: self.increment())
 
 
 if __name__ == '__main__':

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -13,7 +13,7 @@ class CustomFormatStrings(unittest.TestCase):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=5, callback=self.custom_callback, format_string="{i}"))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_callback, format_string="{i}"))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
 
     def test_custom_unbounded(self):
@@ -38,7 +38,7 @@ class CustomFormatFunctions(unittest.TestCase):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=5, callback=self.custom_print_callback, format_callback=self.custom_format_callback))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_print_callback, format_callback=self.custom_format_callback))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_results["Odd"], 10)
         self.assertEqual(self.callback_results["Even"], 10)
@@ -51,19 +51,19 @@ class BoundedTests(unittest.TestCase):
     def increment(self):
         self.callback_count += 1
 
-    def test_every_x_percent(self):
+    def test_every_n_percent(self):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=5, callback=lambda _: self.increment()))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 20)
 
-    def test_every_x_percent_while_including_first(self):
+    def test_every_n_percent_while_including_first(self):
         # [0,5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=5, ignore_first_iteration=False, callback=lambda _: self.increment()))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, ignore_first_iteration=False, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 21)
 
@@ -104,17 +104,17 @@ class BoundedTests(unittest.TestCase):
                 time.sleep(IDLE_SECONDS_TRIGGER + 2)
         self.assertEqual(self.callback_count, 1)
 
-    def test_every_x_percent_every_y_records(self):
+    def test_every_n_percent_every_y_records(self):
         NUMBER_OF_ITERATIONS = 100
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=10, every_n_records=11, callback=lambda _: self.increment()))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=10, every_n_records=11, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 19)
 
     def test_record_keeping(self):
         NUMBER_OF_ITERATIONS = 100
 
-        pt = track_progress(range(0, NUMBER_OF_ITERATIONS), every_x_percent=10, every_n_records=11, callback=lambda _: self.increment())
+        pt = track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=10, every_n_records=11, callback=lambda _: self.increment())
         results = list(pt)
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(len(results), pt.items_seen)
@@ -132,16 +132,16 @@ class UnboundedTests(unittest.TestCase):
     def increment(self):
         self.callback_count += 1
 
-    def test_every_x_percent(self):
+    def test_every_n_percent(self):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        # every_x_percent doesn't make sense when you don't know the size (because it is a generator)
+        # every_n_percent doesn't make sense when you don't know the size (because it is a generator)
         with self.assertRaises(Exception):
-            track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_x_percent=5, callback=lambda _: self.increment())
+            track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_n_percent=5, callback=lambda _: self.increment())
 
         # But if you happen to know the size a priori, you can pass it in
-        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), total=NUMBER_OF_ITERATIONS, every_x_percent=5, callback=lambda _: self.increment()))
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), total=NUMBER_OF_ITERATIONS, every_n_percent=5, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 20)
 
@@ -174,10 +174,10 @@ class UnboundedTests(unittest.TestCase):
                 time.sleep(IDLE_SECONDS_TRIGGER + 2)
         self.assertEqual(self.callback_count, 1)
 
-    def test_every_x_percent_every_y_records(self):
+    def test_every_n_percent_every_y_records(self):
         NUMBER_OF_ITERATIONS = 100
 
-        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), total=NUMBER_OF_ITERATIONS, every_x_percent=10, every_n_records=11, callback=lambda _: self.increment()))
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), total=NUMBER_OF_ITERATIONS, every_n_percent=10, every_n_records=11, callback=lambda _: self.increment()))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
         self.assertEqual(self.callback_count, 19)
 

--- a/tests/test_progress_tracker.py
+++ b/tests/test_progress_tracker.py
@@ -13,14 +13,14 @@ class CustomFormatStrings(unittest.TestCase):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_callback, format_callback=lambda **kwargs: "{i}".format(**kwargs)))
+        results = list(track_progress(range(0, NUMBER_OF_ITERATIONS), every_n_percent=5, callback=self.custom_callback, format_callback=lambda report, _reasons: "{records_seen}".format(**report)))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
 
     def test_custom_unbounded(self):
         # [5,10...100]
         NUMBER_OF_ITERATIONS = 101
 
-        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_n_records=5, callback=self.custom_callback, format_callback=lambda **kwargs: "{i}".format(**kwargs)))
+        results = list(track_progress((i for i in range(0, NUMBER_OF_ITERATIONS)), every_n_records=5, callback=self.custom_callback, format_callback=lambda report, _reasons: "{records_seen}".format(**report)))
         self.assertEqual(len(results), NUMBER_OF_ITERATIONS)
 
 
@@ -31,8 +31,8 @@ class CustomFormatFunctions(unittest.TestCase):
     def custom_print_callback(self, message):
         self.callback_results[message] += 1
 
-    def custom_format_callback(self, **kwargs):
-        return "Odd" if kwargs['i'] % 2 == 1 else "Even"
+    def custom_format_callback(self, report, reasons):
+        return "Odd" if report['records_seen'] % 2 == 1 else "Even"
 
     def test_custom_bounded(self):
         # [5,10...100]
@@ -196,7 +196,7 @@ class UnboundedTests(unittest.TestCase):
         self.assertEqual(self.callback_count, 19)
 
     def test_format_strings(self):
-        track_progress((i for i in range(0, 100)), total=100, format_callback=lambda **kwargs: "{percent_complete}".format(**kwargs), every_n_records=11, callback=lambda _: self.increment())
+        track_progress((i for i in range(0, 100)), total=100, format_callback=lambda report, _reasons: "{percent_complete}".format(**report), every_n_records=11, callback=lambda _: self.increment())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Fixed the consistency issues (Solves #3 and Solves #10).
* Removed `format_string` (Solves #2)
* Refactored the internals to have greater separation of concern.
* The reason(s) for the reports is now passed to format_callback. Allows for advanced print customization. (Solves #9).
* every_n_seconds_idle now reports the idle time correctly, without the processing time included.